### PR TITLE
Switch to HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 
     <!-- dependencies: Raphael, jQuery -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/raphael/2.1.0/raphael-min.js" type="text/javascript"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/raphael/2.1.0/raphael-min.js" type="text/javascript"></script>
 
     <!-- algorithm, simulation code, and styling -->
     <script type="text/javascript" src="algorithm.js"></script>
@@ -27,7 +27,7 @@
         Fundamental Distributed Computing Problem"</em> by Afek, Alon, Barad,
         Hornstein, Barkai, and Bar-Joseph. Primitive nodes, following a
         simple probabilistic broadcast/receive procedure, elect a  
-          <a href="http://en.wikipedia.org/wiki/Maximal_independent_set">maximal independent set</a>
+          <a href="https://en.wikipedia.org/wiki/Maximal_independent_set">maximal independent set</a>
         with very high probability. This new algorithm is inspired by processes
         in the developing nervous system of a fly!
         </p>


### PR DESCRIPTION
Now that GitHub Pages is HTTPS, Raphael.js needs to be too, or it will fail to load due to mixed content restrictions. Also update the Wikipedia link too now that it's fully HTTPS too.