### PR TITLE
Fix broken URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ from "A Biological Solution to a Fundamental Distributed Computing Problem" by
 Afek et al. (sorry I don't have a link to the PDF, and respect you too much to
 link you to a paywall).
 
-You can [play with it](http://jberryman.github.com/fly-mis/)
+You can [play with it](https://jberryman.github.io/fly-mis/)
 or [check out the code](https://github.com/jberryman/fly-mis) on GitHub; 
 in particular, see 
 ["algorithm.js"](https://github.com/jberryman/fly-mis/blob/master/algorithm.js)

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 </head>
 
 <body id="home">
-    <a href="https://github.com/jberryman/fly-mis"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
+    <a href="https://github.com/jberryman/fly-mis"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
     <div id="about">
         <p>


### PR DESCRIPTION
Switch to the new URLs mentioned in these two posts, since the old ones no longer work:
* https://github.blog/news-insights/github-ribbons/
* https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/